### PR TITLE
Update workflows to deploy to Minio S3

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -42,11 +42,6 @@ on:
         default: true
         required: false
         type: boolean
-      catbox_upload:
-        description: "Upload iPA to Catbox.moe (URL)"
-        default: false
-        required: false
-        type: boolean
       upload_to_s3:
         description: "Upload iPA to MinIO S3"
         default: false
@@ -205,19 +200,6 @@ jobs:
           path: ${{ github.workspace }}/main/packages/${{ steps.build_package.outputs.package }}
           if-no-files-found: error
           
-      - name: Upload Artifact to Catbox
-        if: ${{ inputs.catbox_upload }}
-        run: |
-          RESPONSE=$(curl -F "reqtype=fileupload" -F "fileToUpload=@${{ github.workspace }}/main/packages/${{ steps.build_package.outputs.package }}" https://catbox.moe/user/api.php)
-          CATBOX_URL=$(echo $RESPONSE | grep -o -E 'https://files.catbox.moe/[^"]*')
-          echo "Uploaded artifact to $CATBOX_URL"
-          CATBOX_FILE=$(echo $CATBOX_URL | sed 's|https://files.catbox.moe/||')
-          # Pass Catbox URL to the release steps
-          echo "CATBOX_FILE=$CATBOX_FILE" >> $GITHUB_ENV
-          echo "CATBOX_URL=$CATBOX_URL" >> $GITHUB_ENV
-      
-
-
       - name: Upload to MinIO S3
         if: ${{ inputs.upload_to_s3 }}
         run: |
@@ -233,8 +215,6 @@ jobs:
           echo "S3_URL=$S3_URL" >> $GITHUB_ENV
           echo "Uploaded to MinIO S3: $S3_URL"
 
-
-
       - name: Job Summary
         run: |
           echo -e '### 📺 Build Complete' >> $GITHUB_STEP_SUMMARY
@@ -243,11 +223,6 @@ jobs:
         if: ${{ inputs.upload_artifact }}
         run: |
           echo -e '### 📦 Artifact Upload\n\nThe artifact was uploaded successfully! Refresh and [scroll down](#artifacts) to view the artifact. Note that you must be signed in to GitHub to download it.' >> $GITHUB_STEP_SUMMARY
-
-      - name: Job Summary - Catbox Upload
-        if: ${{ inputs.catbox_upload}}
-        run: |
-          echo -e '### 🐱 Catbox Upload\n\nThe Catbox upload was successful! Here is a permanent shareable link: '$CATBOX_URL >> $GITHUB_STEP_SUMMARY
 
       - name: Job Summary - MinIO S3 Upload
         if: ${{ inputs.upload_to_s3 }}

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -52,6 +52,16 @@ on:
         default: false
         required: false
         type: boolean
+      download_from_s3:
+        description: "Download base IPA from MinIO S3 instead of provided URL"
+        default: false
+        required: false
+        type: boolean
+      s3_ipa_path:
+        description: "S3 path to download IPA from (e.g., releases/YouTube_19.01.2_5.0.1/YTLitePlus_19.01.2_5.0.1.ipa)"
+        default: ""
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -132,10 +142,27 @@ jobs:
           echo ::add-mask::$URL_YT
           echo URL_YT=$URL_YT >> $GITHUB_ENV
 
+      - name: Configure AWS CLI for MinIO (Download)
+        if: ${{ inputs.download_from_s3 }}
+        run: |
+          pip install awscli
+          aws configure set aws_access_key_id ${{ secrets.MINIO_ACCESS_KEY }}
+          aws configure set aws_secret_access_key ${{ secrets.MINIO_SECRET_KEY }}
+          aws configure set default.region us-east-1
+          aws configure set default.output json
+
       - name: Prepare YouTube iPA
         run: |
           # Download and unzip iPA
-          wget "$YOUTUBE_URL" --quiet --no-verbose -O main/YouTube.ipa
+          if [ "${{ inputs.download_from_s3 }}" == "true" ]; then
+            echo "Downloading IPA from MinIO S3..."
+            aws s3 cp "s3://${{ secrets.MINIO_BUCKET_NAME }}/${{ inputs.s3_ipa_path }}" \
+              main/YouTube.ipa \
+              --endpoint-url ${{ secrets.MINIO_ENDPOINT_URL }}
+          else
+            echo "Downloading IPA from provided URL..."
+            wget "$YOUTUBE_URL" --quiet --no-verbose -O main/YouTube.ipa
+          fi
           unzip -q main/YouTube.ipa -d main/tmp
           # Get the version number of the YouTube app and store it
           echo "YT_VERSION=$(grep -A 1 '<key>CFBundleVersion</key>' main/tmp/Payload/YouTube.app/Info.plist | grep '<string>' | awk -F'[><]' '{print $3}')" >> $GITHUB_ENV
@@ -212,8 +239,8 @@ jobs:
           echo "CATBOX_FILE=$CATBOX_FILE" >> $GITHUB_ENV
           echo "CATBOX_URL=$CATBOX_URL" >> $GITHUB_ENV
       
-      - name: Configure AWS CLI for MinIO
-        if: ${{ inputs.upload_to_s3 }}
+      - name: Configure AWS CLI for MinIO (Upload)
+        if: ${{ inputs.upload_to_s3 && !inputs.download_from_s3 }}
         run: |
           pip install awscli
           aws configure set aws_access_key_id ${{ secrets.MINIO_ACCESS_KEY }}

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -6,7 +6,6 @@
 # - MINIO_SECRET_KEY: Your MinIO secret key  
 # - MINIO_ENDPOINT_URL: Your MinIO server endpoint (e.g., https://minio.example.com)
 # - MINIO_BUCKET_NAME: The S3 bucket name to upload to
-# - PERSONAL_ACCESS_TOKEN: GitHub PAT for triggering Altstore updates (if used)
 
 name: Build and Release YTLitePlus
 
@@ -237,15 +236,7 @@ jobs:
           echo "S3_URL=$S3_URL" >> $GITHUB_ENV
           echo "Uploaded to MinIO S3: $S3_URL"
 
-      - name: Update Altstore Source with latest release
-        if: ${{ inputs.upload_to_s3 }}
-        run: |
-          curl --location --request POST 'https://api.github.com/repos/Balackburn/YTLitePlusAltstore/dispatches' \
-          --header 'Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}' \
-          --header 'Content-Type: application/json' \
-          --data-raw '{
-            "event_type": "update-altstore-source-trigger"
-          }'
+
 
       - name: Job Summary
         run: |

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -1,6 +1,13 @@
 # Original idea by @ISnackable. Many thanks to him for handling the most hardest parts!
 # https://github.com/ISnackable/CercubePlus/blob/main/.github/workflows/Build.yml
 
+# Required GitHub Secrets for MinIO S3 upload:
+# - MINIO_ACCESS_KEY: Your MinIO access key
+# - MINIO_SECRET_KEY: Your MinIO secret key  
+# - MINIO_ENDPOINT_URL: Your MinIO server endpoint (e.g., https://minio.example.com)
+# - MINIO_BUCKET_NAME: The S3 bucket name to upload to
+# - PERSONAL_ACCESS_TOKEN: GitHub PAT for triggering Altstore updates (if used)
+
 name: Build and Release YTLitePlus
 
 on:
@@ -41,8 +48,8 @@ on:
         default: false
         required: false
         type: boolean
-      create_release:
-        description: "Create a draft release (Private)"
+      upload_to_s3:
+        description: "Upload iPA to MinIO S3"
         default: false
         required: false
         type: boolean
@@ -206,28 +213,32 @@ jobs:
           echo "CATBOX_FILE=$CATBOX_FILE" >> $GITHUB_ENV
           echo "CATBOX_URL=$CATBOX_URL" >> $GITHUB_ENV
       
-      - name: Prepare Release Notes
-        if: ${{ inputs.create_release }}
+      - name: Configure AWS CLI for MinIO
+        if: ${{ inputs.upload_to_s3 }}
         run: |
-          export TODAY=$(date '+%Y-%m-%d')
-          sed "s/%ytliteplus_version%/${{ env.YTLITE_VERSION }}/g; s/%youtube_version%/5.0.1/g; s/%catbox_url%/${{ env.CATBOX_FILE }}/g; s/%date%/$TODAY/g" \
-          main/.github/RELEASE_TEMPLATE/Release.md > ${{ github.workspace }}/release_notes.md
+          pip install awscli
+          aws configure set aws_access_key_id ${{ secrets.MINIO_ACCESS_KEY }}
+          aws configure set aws_secret_access_key ${{ secrets.MINIO_SECRET_KEY }}
+          aws configure set default.region us-east-1
+          aws configure set default.output json
 
-      - name: Create Draft Release
-        if: ${{ inputs.create_release }}
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ env.YT_VERSION }}-5.0.1
-          name: v${{ env.YT_VERSION }}-5.0.1 - YTLitePlus
-          files: main/packages/*.ipa
-          draft: true
-          body_path: ${{ github.workspace }}/release_notes.md
+      - name: Upload to MinIO S3
+        if: ${{ inputs.upload_to_s3 }}
+        run: |
+          PACKAGE_NAME="${{ steps.build_package.outputs.package }}"
+          S3_KEY="releases/YTLitePlus_${{ env.YT_VERSION }}_${{ env.YTLITE_VERSION }}/${PACKAGE_NAME}"
+          
+          aws s3 cp "${{ github.workspace }}/main/packages/${PACKAGE_NAME}" \
+            "s3://${{ secrets.MINIO_BUCKET_NAME }}/${S3_KEY}" \
+            --endpoint-url ${{ secrets.MINIO_ENDPOINT_URL }}
+          
+          # Generate public URL (adjust based on your MinIO setup)
+          S3_URL="${{ secrets.MINIO_ENDPOINT_URL }}/${{ secrets.MINIO_BUCKET_NAME }}/${S3_KEY}"
+          echo "S3_URL=$S3_URL" >> $GITHUB_ENV
+          echo "Uploaded to MinIO S3: $S3_URL"
 
       - name: Update Altstore Source with latest release
-        if: ${{ inputs.create_release }}
+        if: ${{ inputs.upload_to_s3 }}
         run: |
           curl --location --request POST 'https://api.github.com/repos/Balackburn/YTLitePlusAltstore/dispatches' \
           --header 'Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}' \
@@ -250,12 +261,10 @@ jobs:
         run: |
           echo -e '### 🐱 Catbox Upload\n\nThe Catbox upload was successful! Here is a permanent shareable link: '$CATBOX_URL >> $GITHUB_STEP_SUMMARY
 
-      - name: Job Summary - Draft Release
-        if: ${{ inputs.create_release }}
+      - name: Job Summary - MinIO S3 Upload
+        if: ${{ inputs.upload_to_s3 }}
         run: |
-          REPO_URL="https://github.com/${{ github.repository }}"
-          RELEASES_URL="$REPO_URL/releases"
-          echo -e '### 🚀 Draft Release\n\nThe release draft has been created successfully! You can view your releases here: '$RELEASES_URL >> $GITHUB_STEP_SUMMARY
+          echo -e '### 🗄️ MinIO S3 Upload\n\nThe upload to MinIO S3 was successful! File URL: '$S3_URL >> $GITHUB_STEP_SUMMARY
 
       - name: Job Summary - Link to remove GitHub Action runs
         run: |

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -17,8 +17,8 @@ on:
         default: "17.5"
         required: true
         type: string
-      decrypted_youtube_url:
-        description: "Direct URL of the decrypted YouTube ipa"
+      s3_ipa_path:
+        description: "S3 path to download IPA from (e.g., releases/YouTube_19.01.2_5.0.1/YTLitePlus_19.01.2_5.0.1.ipa)"
         default: ""
         required: true
         type: string
@@ -52,16 +52,6 @@ on:
         default: false
         required: false
         type: boolean
-      download_from_s3:
-        description: "Download base IPA from MinIO S3 instead of provided URL"
-        default: false
-        required: false
-        type: boolean
-      s3_ipa_path:
-        description: "S3 path to download IPA from (e.g., releases/YouTube_19.01.2_5.0.1/YTLitePlus_19.01.2_5.0.1.ipa)"
-        default: ""
-        required: false
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -136,14 +126,7 @@ jobs:
           (echo export PATH="/usr/local/opt/make/libexec/gnubin:$PATH" >> ~/.bash_profile)
           source ~/.bash_profile
 
-      - name: Hash YT ipa url
-        run: |
-          URL_YT="$(jq -r '.inputs.decrypted_youtube_url' $GITHUB_EVENT_PATH)"
-          echo ::add-mask::$URL_YT
-          echo URL_YT=$URL_YT >> $GITHUB_ENV
-
-      - name: Configure AWS CLI for MinIO (Download)
-        if: ${{ inputs.download_from_s3 }}
+      - name: Configure AWS CLI for MinIO
         run: |
           pip install awscli
           aws configure set aws_access_key_id ${{ secrets.MINIO_ACCESS_KEY }}
@@ -153,16 +136,11 @@ jobs:
 
       - name: Prepare YouTube iPA
         run: |
-          # Download and unzip iPA
-          if [ "${{ inputs.download_from_s3 }}" == "true" ]; then
-            echo "Downloading IPA from MinIO S3..."
-            aws s3 cp "s3://${{ secrets.MINIO_BUCKET_NAME }}/${{ inputs.s3_ipa_path }}" \
-              main/YouTube.ipa \
-              --endpoint-url ${{ secrets.MINIO_ENDPOINT_URL }}
-          else
-            echo "Downloading IPA from provided URL..."
-            wget "$YOUTUBE_URL" --quiet --no-verbose -O main/YouTube.ipa
-          fi
+          # Download IPA from MinIO S3
+          echo "Downloading IPA from MinIO S3..."
+          aws s3 cp "s3://${{ secrets.MINIO_BUCKET_NAME }}/${{ inputs.s3_ipa_path }}" \
+            main/YouTube.ipa \
+            --endpoint-url ${{ secrets.MINIO_ENDPOINT_URL }}
           unzip -q main/YouTube.ipa -d main/tmp
           # Get the version number of the YouTube app and store it
           echo "YT_VERSION=$(grep -A 1 '<key>CFBundleVersion</key>' main/tmp/Payload/YouTube.app/Info.plist | grep '<string>' | awk -F'[><]' '{print $3}')" >> $GITHUB_ENV
@@ -194,7 +172,6 @@ jobs:
           cp -R main/Extensions/*.appex main/tmp/Payload/YouTube.app/PlugIns
         env:
           THEOS: ${{ github.workspace }}/theos
-          YOUTUBE_URL: ${{ env.URL_YT }}
 
       - name: Build Package
         id: build_package
@@ -239,14 +216,7 @@ jobs:
           echo "CATBOX_FILE=$CATBOX_FILE" >> $GITHUB_ENV
           echo "CATBOX_URL=$CATBOX_URL" >> $GITHUB_ENV
       
-      - name: Configure AWS CLI for MinIO (Upload)
-        if: ${{ inputs.upload_to_s3 && !inputs.download_from_s3 }}
-        run: |
-          pip install awscli
-          aws configure set aws_access_key_id ${{ secrets.MINIO_ACCESS_KEY }}
-          aws configure set aws_secret_access_key ${{ secrets.MINIO_SECRET_KEY }}
-          aws configure set default.region us-east-1
-          aws configure set default.output json
+
 
       - name: Upload to MinIO S3
         if: ${{ inputs.upload_to_s3 }}

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -19,17 +19,17 @@ on:
         type: string
       s3_ipa_path:
         description: "S3 path to download IPA from (e.g., releases/YouTube_19.01.2_5.0.1/YTLitePlus_19.01.2_5.0.1.ipa)"
-        default: ""
+        default: "com.google.ios.youtube-20.30.5-Decrypted.ipa"
         required: true
         type: string
       bundle_id:
         description: "Modify the bundle ID"
-        default: "com.google.ios.youtube"
+        default: "com.test.freetube"
         required: true
         type: string
       app_name:
         description: "Modify the app name"
-        default: "YouTube"
+        default: "FreeTube"
         required: true
         type: string
       commit_id:
@@ -37,11 +37,6 @@ on:
         default: ""
         required: false
         type: string
-      upload_artifact:
-        description: "Upload iPA as artifact (Public)"
-        default: true
-        required: false
-        type: boolean
       upload_to_s3:
         description: "Upload iPA to MinIO S3"
         default: false
@@ -191,14 +186,6 @@ jobs:
           THEOS: ${{ github.workspace }}/theos
           BUNDLE_ID: ${{ inputs.bundle_id }}
           APP_NAME: ${{ inputs.app_name }}
-
-      - name: Upload Artifact
-        if: ${{ inputs.upload_artifact }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: YTLitePlus_${{ env.YT_VERSION }}_${{ env.YTLITE_VERSION }}
-          path: ${{ github.workspace }}/main/packages/${{ steps.build_package.outputs.package }}
-          if-no-files-found: error
           
       - name: Upload to MinIO S3
         if: ${{ inputs.upload_to_s3 }}


### PR DESCRIPTION
Modify GitHub Actions workflow to upload releases to MinIO S3 instead of creating GitHub releases.

---

[Open in Web](https://cursor.com/agents?id=bc-eb76347e-930e-49a4-9070-1496700f6fb5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-eb76347e-930e-49a4-9070-1496700f6fb5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)